### PR TITLE
Update grid-federation-retry-failed-replication.adoc

### DIFF
--- a/admin/grid-federation-retry-failed-replication.adoc
+++ b/admin/grid-federation-retry-failed-replication.adoc
@@ -136,7 +136,7 @@ You can monitor retry operations in either of two ways:
 | Grid| Replication status 
 
 | Source
-| * *SUCCESS*: The replication was successful.
+| * *COMPLETED*: The replication was successful.
 * *PENDING*: The object hasn't been replicated yet.
 * *FAILURE*: The replication failed with a permanent failure. A user must resolve the error.
 


### PR DESCRIPTION
changed grid replication status from 'success' to 'completed' when checking x-ntap-sg-cgr-replication-status header. This is the correct status shown for the header and also mentioned in line 167 as the status for successful replication.