### PR TITLE
Update grid-federation-what-is-cross-grid-replication.adoc

### DIFF
--- a/admin/grid-federation-what-is-cross-grid-replication.adoc
+++ b/admin/grid-federation-what-is-cross-grid-replication.adoc
@@ -61,7 +61,7 @@ The S3 client can verify an object's replication status by issuing a GET Object 
 | Grid| Replication status 
 
 | Source
-| * *SUCCESS*: The replication was successful for all grid connections.
+| * *COMPLETED*: The replication was successful for all grid connections.
 * *PENDING*: The object hasn't been replicated to at least one grid connection.
 * *FAILURE*: Replication is not pending for any grid connection and at least one failed with a permanent failure. A user must resolve the error.
 


### PR DESCRIPTION
changed grid replication status from 'success' to 'completed' when checking x-ntap-sg-cgr-replication-status header. This is the correct status shown for the header as mentioned in line 167 in grid-federation-retry-failed-replication.adoc for successful replication.