### PR TITLE
Update head-object.adoc

### DIFF
--- a/s3/head-object.adoc
+++ b/s3/head-object.adoc
@@ -112,7 +112,7 @@ If you are using link:../admin/grid-federation-overview.html[grid federation] an
 | Grid| Replication status 
 
 | Source
-| * *SUCCESS*: The replication was successful.
+| * *COMPLETED*: The replication was successful.
 * *PENDING*: The object hasn't been replicated yet.
 * *FAILURE*: The replication failed with a permanent failure. A user must resolve the error.
 


### PR DESCRIPTION
changed grid replication status from 'success' to 'completed' when checking x-ntap-sg-cgr-replication-status header. This is the correct status shown for the header as mentioned in line 167 in grid-federation-retry-failed-replication.adoc for successful replication.